### PR TITLE
Update scalafmt-core to 3.3.1

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Check headers
       run: sbt +headerCheck
     - name: Check scalafmt
-      run: sbt +scalafmtCheckAll
+      run: sbt +scalafmtCheckAll scalafmtSbtCheck
     - name: Run tests
       run: sbt +test

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.3.0
+version = 3.3.1
 
 runner.dialect = scala211
 

--- a/bench/src/main/scala/pt/kcry/blake3/benchmark/Blake3Benchmark.scala
+++ b/bench/src/main/scala/pt/kcry/blake3/benchmark/Blake3Benchmark.scala
@@ -38,15 +38,8 @@ class Blake3Benchmark {
   }
 
   @Benchmark
-  def newHasher(): Unit =
-    Blake3
-      .newHasher()
-      .update(data)
-      .done(hashBytes)
+  def newHasher(): Unit = Blake3.newHasher().update(data).done(hashBytes)
 
   @Benchmark
-  def reusedHasher(): Unit =
-    hasher
-      .update(data)
-      .done(hashBytes)
+  def reusedHasher(): Unit = hasher.update(data).done(hashBytes)
 }

--- a/bench/src/main/scala/pt/kcry/blake3/benchmark/Blake3JNIBenchmark.scala
+++ b/bench/src/main/scala/pt/kcry/blake3/benchmark/Blake3JNIBenchmark.scala
@@ -82,28 +82,22 @@ object Blake3JNI {
   private val createHasherMethod = jniCls.getDeclaredMethod("create_hasher");
   createHasherMethod.setAccessible(true)
 
-  private val destroyHasherMethod =
-    jniCls.getDeclaredMethod("destroy_hasher", classOf[Long]);
+  private val destroyHasherMethod = jniCls
+    .getDeclaredMethod("destroy_hasher", classOf[Long]);
   destroyHasherMethod.setAccessible(true)
 
-  private val blake3HasherInitMethod =
-    jniCls.getDeclaredMethod("blake3_hasher_init", classOf[Long]);
+  private val blake3HasherInitMethod = jniCls
+    .getDeclaredMethod("blake3_hasher_init", classOf[Long]);
   blake3HasherInitMethod.setAccessible(true)
 
-  private val blake3HasherUpdateMethod = jniCls.getDeclaredMethod(
-    "blake3_hasher_update",
-    classOf[Long],
-    classOf[ByteBuffer],
-    classOf[Int]
-  );
+  private val blake3HasherUpdateMethod = jniCls
+    .getDeclaredMethod("blake3_hasher_update", classOf[Long],
+      classOf[ByteBuffer], classOf[Int]);
   blake3HasherUpdateMethod.setAccessible(true)
 
-  private val blake3HasherFinalize = jniCls.getDeclaredMethod(
-    "blake3_hasher_finalize",
-    classOf[Long],
-    classOf[ByteBuffer],
-    classOf[Int]
-  );
+  private val blake3HasherFinalize = jniCls
+    .getDeclaredMethod("blake3_hasher_finalize", classOf[Long],
+      classOf[ByteBuffer], classOf[Int]);
   blake3HasherFinalize.setAccessible(true)
 
   def create(): Long = {
@@ -112,17 +106,13 @@ object Blake3JNI {
     hasher
   }
 
-  def destroy(hasher: Long): Unit =
-    destroyHasherMethod.invoke(null, hasher)
+  def destroy(hasher: Long): Unit = destroyHasherMethod.invoke(null, hasher)
 
-  def init(hasher: Long): Unit =
-    blake3HasherInitMethod.invoke(null, hasher)
+  def init(hasher: Long): Unit = blake3HasherInitMethod.invoke(null, hasher)
 
-  def update(hasher: Long, data: ByteBuffer, len: Int): Unit = synchronized {
-    blake3HasherUpdateMethod.invoke(null, hasher, data, len)
-  }
+  def update(hasher: Long, data: ByteBuffer, len: Int): Unit =
+    synchronized(blake3HasherUpdateMethod.invoke(null, hasher, data, len))
 
-  def done(hasher: Long, output: ByteBuffer, len: Int): Unit = synchronized {
-    blake3HasherFinalize.invoke(null, hasher, output, len)
-  }
+  def done(hasher: Long, output: ByteBuffer, len: Int): Unit =
+    synchronized(blake3HasherFinalize.invoke(null, hasher, output, len))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -20,80 +20,51 @@ ThisBuild / dynverSeparator := "-"
 ThisBuild / scalaVersion := scala213
 ThisBuild / crossScalaVersions := Seq()
 
-ThisBuild / scalacOptions ++= Seq(
-  "-target:jvm-1.8",
-  "-unchecked",
-  "-deprecation"
-)
+ThisBuild / scalacOptions ++=
+  Seq("-target:jvm-1.8", "-unchecked", "-deprecation")
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
 headerLicense := LicenseDefinition.template
 
 lazy val blake3 = crossProject(JSPlatform, JVMPlatform, NativePlatform)
-  .crossType(CrossType.Full)
-  .enablePlugins(BuildInfoPlugin)
-  .enablePlugins(AutomateHeaderPlugin)
-  .in(file("."))
-  .settings(
+  .crossType(CrossType.Full).enablePlugins(BuildInfoPlugin)
+  .enablePlugins(AutomateHeaderPlugin).in(file(".")).settings(
     // Don't publish for Scala 3.1 or later, only from 3.0
-    publish / skip := (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((3, x)) if x > 0 => true
-      case _                     => false
-    }),
+    publish / skip :=
+      (CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, x)) if x > 0 => true
+        case _                     => false
+      }),
     Test / publishArtifact := false,
-    buildInfoKeys := Seq(
-      BuildInfoKey.action("commit") {
-        scala.sys.process.Process("git rev-parse HEAD").!!.trim
-      }
-    ),
+    buildInfoKeys := Seq(BuildInfoKey.action("commit") {
+      scala.sys.process.Process("git rev-parse HEAD").!!.trim
+    }),
     headerLicense := LicenseDefinition.template,
     buildInfoPackage := "pt.kcry.blake3",
-    libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % scalatestVersion % Test
-    )
-  )
-  .jvmSettings(
-    scalaVersion := scala213,
-    crossScalaVersions := Seq(
-      scala210,
-      scala211,
-      scala212,
-      scala213,
-      scala30,
-      scala31
-    )
-  )
-  .jsSettings(
-    scalaVersion := scala213,
-    crossScalaVersions := Seq(scala211, scala212, scala213, scala30, scala31)
-  )
-  .nativeSettings(
-    scalaVersion := scala213,
+    libraryDependencies ++=
+      Seq("org.scalatest" %%% "scalatest" % scalatestVersion % Test)
+  ).jvmSettings(scalaVersion := scala213,
+    crossScalaVersions :=
+      Seq(scala210, scala211, scala212, scala213, scala30, scala31)
+  ).jsSettings(scalaVersion := scala213,
+    crossScalaVersions := Seq(scala211, scala212, scala213, scala30, scala31))
+  .nativeSettings(scalaVersion := scala213,
     crossScalaVersions := Seq(scala211, scala212, scala213),
-    nativeLinkStubs := true
-  )
+    nativeLinkStubs := true)
 
-lazy val bench = project
-  .in(file("bench"))
-  .dependsOn(blake3.jvm)
-  .enablePlugins(AutomateHeaderPlugin)
-  .settings(
+lazy val bench = project.in(file("bench")).dependsOn(blake3.jvm)
+  .enablePlugins(AutomateHeaderPlugin).settings(
     name := "blake3-bench",
     publish / skip := true,
     assembly / assemblyJarName := "bench.jar",
     assembly / mainClass := Some("org.openjdk.jmh.Main"),
     assembly / test := {},
-    libraryDependencies ++= Seq(
-      "io.lktk" % "blake3jni" % blake3jniVersion
-    ),
+    libraryDependencies ++= Seq("io.lktk" % "blake3jni" % blake3jniVersion),
     headerLicense := LicenseDefinition.template,
     assembly / assemblyMergeStrategy := {
-      case PathList("META-INF", "MANIFEST.MF") =>
-        MergeStrategy.discard
-      case _ =>
-        MergeStrategy.first
+      case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+      case _                                   => MergeStrategy.first
     },
     Jmh / assembly := (Jmh / assembly).dependsOn(Jmh / Keys.compile).value
-  )
-  .enablePlugins(JmhPlugin)
+  ).enablePlugins(JmhPlugin)

--- a/project/LicenseDefinition.scala
+++ b/project/LicenseDefinition.scala
@@ -3,9 +3,8 @@ import de.heikoseeberger.sbtheader.License
 import sbt.url
 
 object LicenseDefinition {
-  val template: Option[License.Custom] = Some(
-    HeaderLicense.Custom(
-      """scala-blake3 - highly optimized blake3 implementation for scala, scala-js and scala-native.
+  val template: Option[License.Custom] = Some(HeaderLicense
+    .Custom("""scala-blake3 - highly optimized blake3 implementation for scala, scala-js and scala-native.
       |
       |Written in 2020, 2021 by Kirill A. Korinsky <kirill@korins.ky>
       |
@@ -13,16 +12,12 @@ object LicenseDefinition {
       |
       |This work is released into the public domain with CC0 1.0.
       |Alternatively, it is licensed under the Apache License 2.0.
-      |""".stripMargin
-    )
-  )
+      |""".stripMargin))
 
   val licenses = Seq(
-    "CC0 1.0 Universal" -> url(
-      "https://github.com/kcrypt/scala-blake3/blob/master/LICENSE.txt"
-    ),
-    "Apache License 2.0" -> url(
-      "https://github.com/kcrypt/scala-blake3/blob/master/LICENSE.txt"
-    )
+    "CC0 1.0 Universal" ->
+      url("https://github.com/kcrypt/scala-blake3/blob/master/LICENSE.txt"),
+    "Apache License 2.0" ->
+      url("https://github.com/kcrypt/scala-blake3/blob/master/LICENSE.txt")
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")
 
-val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.8.0")
-val scalaNativeJSVersion =
-  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.2")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.8.0")
+val scalaNativeJSVersion = Option(System.getenv("SCALANATIVE_VERSION"))
+  .getOrElse("0.4.2")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeJSVersion)

--- a/shared/src/main/scala/pt/kcry/blake3/Output.scala
+++ b/shared/src/main/scala/pt/kcry/blake3/Output.scala
@@ -22,10 +22,9 @@ private[blake3] class Output(
   val counter: Long, val blockLen: Int, val flags: Int
 ) {
 
-  def chainingValue(
-    chainingValue: Array[Int]
-  ): Unit = compressInPlace(chainingValue, inputChainingValue, blockWords,
-    counter, blockLen, flags)
+  def chainingValue(chainingValue: Array[Int]): Unit =
+    compressInPlace(chainingValue, inputChainingValue, blockWords, counter,
+      blockLen, flags)
 
   def rootBytes(out: Array[Byte], off: Int, len: Int): Unit = {
     var outputBlockCounter = 0

--- a/shared/src/main/scala/pt/kcry/blake3/RFC4648.scala
+++ b/shared/src/main/scala/pt/kcry/blake3/RFC4648.scala
@@ -69,7 +69,7 @@ object RFC4648 {
       sb append
         alphabet(((bytes(offset) & 0x3) << 4) | ((bytes(offset + 1) >>> 4) & 0xf))
       sb append alphabet(((bytes(offset + 1) & 0xf) << 2) |
-          ((bytes(offset + 2) >>> 6) & 0x3))
+        ((bytes(offset + 2) >>> 6) & 0x3))
       sb append alphabet(bytes(offset + 2) & 0x3f)
   }
 
@@ -97,7 +97,7 @@ object RFC4648 {
         alphabet(((bytes(offset) & 0x7) << 2) | ((bytes(offset + 1) >>> 6) & 0x3))
       sb append alphabet((bytes(offset + 1) >>> 1) & 0x1f)
       sb append alphabet(((bytes(offset + 1) & 0x1) << 4) |
-          ((bytes(offset + 2) >>> 4) & 0xf))
+        ((bytes(offset + 2) >>> 4) & 0xf))
       sb append alphabet((bytes(offset + 2) & 0xf) << 1)
 
     case 4 =>
@@ -106,9 +106,9 @@ object RFC4648 {
         alphabet(((bytes(offset) & 0x7) << 2) | ((bytes(offset + 1) >>> 6) & 0x3))
       sb append alphabet((bytes(offset + 1) >>> 1) & 0x1f)
       sb append alphabet(((bytes(offset + 1) & 0x1) << 4) |
-          ((bytes(offset + 2) >>> 4) & 0xf))
+        ((bytes(offset + 2) >>> 4) & 0xf))
       sb append alphabet(((bytes(offset + 2) & 0xf) << 1) |
-          ((bytes(offset + 3) >>> 7) & 0x1))
+        ((bytes(offset + 3) >>> 7) & 0x1))
       sb append alphabet((bytes(offset + 3) >>> 2) & 0x1f)
       sb append alphabet((bytes(offset + 3) & 0x3) << 3)
 
@@ -118,12 +118,12 @@ object RFC4648 {
         alphabet(((bytes(offset) & 0x7) << 2) | ((bytes(offset + 1) >>> 6) & 0x3))
       sb append alphabet((bytes(offset + 1) >>> 1) & 0x1f)
       sb append alphabet(((bytes(offset + 1) & 0x1) << 4) |
-          ((bytes(offset + 2) >>> 4) & 0xf))
+        ((bytes(offset + 2) >>> 4) & 0xf))
       sb append alphabet(((bytes(offset + 2) & 0xf) << 1) |
-          ((bytes(offset + 3) >>> 7) & 0x1))
+        ((bytes(offset + 3) >>> 7) & 0x1))
       sb append alphabet((bytes(offset + 3) >>> 2) & 0x1f)
       sb append alphabet(((bytes(offset + 3) & 0x3) << 3) |
-          ((bytes(offset + 4) >>> 5) & 0x7))
+        ((bytes(offset + 4) >>> 5) & 0x7))
       sb append alphabet(bytes(offset + 4) & 0x1f)
   }
 

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -3,23 +3,14 @@ import xerial.sbt.Sonatype.GitHubHosting
 
 ThisBuild / sonatypeProfileName := "pt.kcry"
 ThisBuild / publishMavenStyle := true
-ThisBuild / sonatypeProjectHosting := Some(
-  GitHubHosting("kcrypt", "scala-sha", "k@kcry.pt")
-)
+ThisBuild / sonatypeProjectHosting :=
+  Some(GitHubHosting("kcrypt", "scala-sha", "k@kcry.pt"))
 ThisBuild / licenses := LicenseDefinition.licenses
 ThisBuild / homepage := Some(url("https://github.com/kcrypt/scala-blake3"))
-ThisBuild / scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/kcrypt/scala-blake3"),
-    "scm:git@github.com:kcrypt/scala-blake3.git"
-  )
-)
-ThisBuild / developers := List(
-  Developer(
-    id = "catap",
-    name = "Kirill A. Korinsky",
-    email = "kirill@korins.ky",
-    url = url("https://github.com/catap")
-  )
-)
+ThisBuild / scmInfo :=
+  Some(ScmInfo(url("https://github.com/kcrypt/scala-blake3"),
+    "scm:git@github.com:kcrypt/scala-blake3.git"))
+ThisBuild / developers :=
+  List(Developer(id = "catap", name = "Kirill A. Korinsky",
+    email = "kirill@korins.ky", url = url("https://github.com/catap")))
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"


### PR DESCRIPTION
It also includes reformating code to follow the brand new rules and enable sbt-checks on CI.

Closes: #49 