### PR TITLE
Really update scala3 to 3.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ lazy val scala210 = "2.10.7"
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.15"
 lazy val scala213 = "2.13.8"
-lazy val scala31 = "3.1.1"
+lazy val scala31 = "3.1.2"
 
-lazy val scalatestVersion = "3.2.10"
+lazy val scalatestVersion = "3.2.12"
 
 lazy val blake3jniVersion = "0.2.2"
 
@@ -40,8 +40,10 @@ lazy val blake3 = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   ).jvmSettings(
     crossScalaVersions := Seq(scala210, scala211, scala212, scala213, scala31)
   ).jsSettings(crossScalaVersions := Seq(scala211, scala212, scala213, scala31))
-  .nativeSettings(crossScalaVersions := Seq(scala211, scala212, scala213),
-    nativeLinkStubs := true)
+  .nativeSettings(
+    crossScalaVersions := Seq(scala211, scala212, scala213, scala31),
+    nativeLinkStubs := true
+  )
 
 lazy val bench = project.in(file("bench")).dependsOn(blake3.jvm)
   .enablePlugins(AutomateHeaderPlugin).settings(


### PR DESCRIPTION
It also enables publishing artifacts for scala-native by scala31

Thus, this is missed part of b70868d58215d747900374e69d00a940f4dc44ef