### PR TITLE
Updated scala toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 ## [unreleased]
+- Drop support scala-2.12 for Scala.JS and Scala-Native
+- Switched to scala-2.12.19
+- Switched to scala-2.13.13
+- Switched to scala-3.4.0
+- Switched to scalajs-1.15.0
+- Switched to scala-native-0.4.7
 
 ## [3.1.1] - 2022-05-19
 - Performance improved: now it's about 20% slower than C version

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 lazy val scala210 = "2.10.7"
 lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.17"
-lazy val scala213 = "2.13.10"
-lazy val scala31 = "3.2.0"
+lazy val scala212 = "2.12.19"
+lazy val scala213 = "2.13.13"
+lazy val scala3 = "3.4.0"
 
 lazy val scalatestVersion = "3.2.18"
 
@@ -16,7 +16,7 @@ ThisBuild / organization := "pt.kcry"
 
 ThisBuild / dynverSeparator := "-"
 
-ThisBuild / scalaVersion := scala31
+ThisBuild / scalaVersion := scala3
 ThisBuild / crossScalaVersions := Seq()
 
 ThisBuild / scalacOptions ++= Seq("-target:jvm-1.8", "-unchecked",
@@ -38,12 +38,10 @@ lazy val blake3 = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies ++=
       Seq("org.scalatest" %%% "scalatest" % scalatestVersion % Test)
   ).jvmSettings(
-    crossScalaVersions := Seq(scala210, scala211, scala212, scala213, scala31)
-  ).jsSettings(crossScalaVersions := Seq(scala211, scala212, scala213, scala31))
-  .nativeSettings(
-    crossScalaVersions := Seq(scala211, scala212, scala213, scala31),
-    nativeLinkStubs := true
-  )
+    crossScalaVersions := Seq(scala210, scala211, scala212, scala213, scala3)
+  ).jsSettings(crossScalaVersions := Seq(scala212, scala213, scala3))
+  .nativeSettings(crossScalaVersions := Seq(scala212, scala213, scala3),
+    nativeLinkStubs := true)
 
 lazy val bench = project.in(file("bench")).dependsOn(blake3.jvm)
   .enablePlugins(AutomateHeaderPlugin).settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.7")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.15.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")


### PR DESCRIPTION
All this changes simple to delivery in one step.

Thus, modern Scala.JS and Scala-Native drop support of scala-2.11 that forces me to do the same.